### PR TITLE
修复 #23 问题

### DIFF
--- a/raft-java-core/src/main/java/com/github/wenweihu86/raft/Peer.java
+++ b/raft-java-core/src/main/java/com/github/wenweihu86/raft/Peer.java
@@ -29,6 +29,12 @@ public class Peer {
         isCatchUp = false;
     }
 
+    public RpcClient createClient() {
+        return new RpcClient(new Endpoint(
+                server.getEndpoint().getHost(),
+                server.getEndpoint().getPort()));
+    }
+
     public RaftProto.Server getServer() {
         return server;
     }
@@ -73,4 +79,5 @@ public class Peer {
     public void setCatchUp(boolean catchUp) {
         isCatchUp = catchUp;
     }
+
 }

--- a/raft-java-example/src/main/java/com/github/wenweihu86/raft/example/server/service/impl/ExampleServiceImpl.java
+++ b/raft-java-example/src/main/java/com/github/wenweihu86/raft/example/server/service/impl/ExampleServiceImpl.java
@@ -21,6 +21,7 @@ public class ExampleServiceImpl implements ExampleService {
 
     private RaftNode raftNode;
     private ExampleStateMachine stateMachine;
+    private ExampleService exampleService;
 
     public ExampleServiceImpl(RaftNode raftNode, ExampleStateMachine stateMachine) {
         this.raftNode = raftNode;
@@ -34,6 +35,10 @@ public class ExampleServiceImpl implements ExampleService {
         if (raftNode.getLeaderId() <= 0) {
             responseBuilder.setSuccess(false);
         } else if (raftNode.getLeaderId() != raftNode.getLocalServer().getServerId()) {
+            if (this.exampleService == null) {
+                RpcClient rpcClient = raftNode.getPeerMap().get(raftNode.getLeaderId()).createClient();
+                exampleService = BrpcProxy.getProxy(rpcClient, ExampleService.class);
+            }
             RpcClient rpcClient = raftNode.getPeerMap().get(raftNode.getLeaderId()).getRpcClient();
             ExampleService exampleService = BrpcProxy.getProxy(rpcClient, ExampleService.class);
             ExampleProto.SetResponse responseFromLeader = exampleService.set(request);


### PR DESCRIPTION
当客户端向集群发起写入请求时，会根据 brpc 的负载均衡策略选取一个节点进行写入，如果被选中的节点不是 Leader 节点，而是从节点，就会报 com.baidu.brpc.exceptions.RpcException: serviceInterface must not be set repeatedly, please use another RpcClient 异常，原因是此时从节点需要向 Leader 发起操作，但是拿到的 rpcClient 已经绑定其它服务接口。